### PR TITLE
Add missing XML parsing for new v1.5 model properties

### DIFF
--- a/src/CloudNimble.DotNetDocs.Sdk.Tasks/GenerateDocumentationTask.cs
+++ b/src/CloudNimble.DotNetDocs.Sdk.Tasks/GenerateDocumentationTask.cs
@@ -552,6 +552,48 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
                     config.Interaction = ParseInteractionConfig(interactionElement);
                 }
 
+                // Parse Api
+                var apiElement = root.Element(nameof(DocsJsonConfig.Api));
+                if (apiElement is not null)
+                {
+                    config.Api = ParseApiConfig(apiElement);
+                }
+
+                // Parse Contextual
+                var contextualElement = root.Element(nameof(DocsJsonConfig.Contextual));
+                if (contextualElement is not null)
+                {
+                    config.Contextual = ParseContextualConfig(contextualElement);
+                }
+
+                // Parse Fonts
+                var fontsElement = root.Element(nameof(DocsJsonConfig.Fonts));
+                if (fontsElement is not null)
+                {
+                    config.Fonts = ParseFontsConfig(fontsElement);
+                }
+
+                // Parse Thumbnails
+                var thumbnailsElement = root.Element(nameof(DocsJsonConfig.Thumbnails));
+                if (thumbnailsElement is not null)
+                {
+                    config.Thumbnails = ParseThumbnailsConfig(thumbnailsElement);
+                }
+
+                // Parse Metadata
+                var metadataElement = root.Element(nameof(DocsJsonConfig.Metadata));
+                if (metadataElement is not null)
+                {
+                    config.Metadata = ParseMetadataConfig(metadataElement);
+                }
+
+                // Parse Errors
+                var errorsElement = root.Element(nameof(DocsJsonConfig.Errors));
+                if (errorsElement is not null)
+                {
+                    config.Errors = ParseErrorsConfig(errorsElement);
+                }
+
                 return (config, docsNavConfig);
             }
             catch (Exception ex)
@@ -1195,6 +1237,86 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
                     ApiKey = posthogElement.Attribute(nameof(PostHogConfig.ApiKey))?.Value,
                     ApiHost = posthogElement.Attribute(nameof(PostHogConfig.ApiHost))?.Value
                 };
+
+                var sessionRecordingAttr = posthogElement.Attribute(nameof(PostHogConfig.SessionRecording))?.Value;
+                if (!string.IsNullOrWhiteSpace(sessionRecordingAttr) && bool.TryParse(sessionRecordingAttr, out var sessionRecording))
+                {
+                    config.PostHog.SessionRecording = sessionRecording;
+                }
+            }
+
+            // Parse Adobe
+            var adobeElement = integrationsElement.Element(nameof(IntegrationsConfig.Adobe));
+            if (adobeElement is not null)
+            {
+                config.Adobe = new AdobeConfig
+                {
+                    LaunchUrl = adobeElement.Attribute(nameof(AdobeConfig.LaunchUrl))?.Value
+                };
+            }
+
+            // Parse Clarity
+            var clarityElement = integrationsElement.Element(nameof(IntegrationsConfig.Clarity));
+            if (clarityElement is not null)
+            {
+                config.Clarity = new ClarityConfig
+                {
+                    ProjectId = clarityElement.Attribute(nameof(ClarityConfig.ProjectId))?.Value
+                };
+            }
+
+            // Parse Cookies
+            var cookiesElement = integrationsElement.Element(nameof(IntegrationsConfig.Cookies));
+            if (cookiesElement is not null)
+            {
+                config.Cookies = new CookiesConfig
+                {
+                    Key = cookiesElement.Attribute(nameof(CookiesConfig.Key))?.Value,
+                    Value = cookiesElement.Attribute(nameof(CookiesConfig.Value))?.Value
+                };
+            }
+
+            // Parse FrontChat
+            var frontChatElement = integrationsElement.Element(nameof(IntegrationsConfig.FrontChat));
+            if (frontChatElement is not null)
+            {
+                config.FrontChat = new FrontChatConfig
+                {
+                    SnippetId = frontChatElement.Attribute(nameof(FrontChatConfig.SnippetId))?.Value
+                };
+            }
+
+            // Parse Intercom
+            var intercomElement = integrationsElement.Element(nameof(IntegrationsConfig.Intercom));
+            if (intercomElement is not null)
+            {
+                config.Intercom = new IntercomConfig
+                {
+                    AppId = intercomElement.Attribute(nameof(IntercomConfig.AppId))?.Value
+                };
+            }
+
+            // Parse Koala
+            var koalaElement = integrationsElement.Element(nameof(IntegrationsConfig.Koala));
+            if (koalaElement is not null)
+            {
+                config.Koala = new KoalaConfig
+                {
+                    PublicApiKey = koalaElement.Attribute(nameof(KoalaConfig.PublicApiKey))?.Value
+                };
+            }
+
+            // Parse Telemetry
+            var telemetryElement = integrationsElement.Element(nameof(IntegrationsConfig.Telemetry));
+            if (telemetryElement is not null)
+            {
+                config.Telemetry = new TelemetryConfig();
+
+                var enabledAttr = telemetryElement.Attribute(nameof(TelemetryConfig.Enabled))?.Value;
+                if (!string.IsNullOrWhiteSpace(enabledAttr) && bool.TryParse(enabledAttr, out var telemetryEnabled))
+                {
+                    config.Telemetry.Enabled = telemetryEnabled;
+                }
             }
 
             // Parse Segment
@@ -1231,6 +1353,16 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
             if (eyebrowsElement is not null && !string.IsNullOrWhiteSpace(eyebrowsElement.Value))
             {
                 config.Eyebrows = eyebrowsElement.Value.Trim();
+            }
+
+            // Parse Latex
+            var latexElement = stylingElement.Element(nameof(StylingConfig.Latex));
+            if (latexElement is not null && !string.IsNullOrWhiteSpace(latexElement.Value))
+            {
+                if (bool.TryParse(latexElement.Value.Trim(), out var latex))
+                {
+                    config.Latex = latex;
+                }
             }
 
             return config;
@@ -1281,6 +1413,379 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
                 if (bool.TryParse(drilldownElement.Value.Trim(), out var drilldown))
                 {
                     config.Drilldown = drilldown;
+                }
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Api element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="apiElement">The API XML element.</param>
+        /// <returns>An ApiConfig instance.</returns>
+        internal ApiConfig ParseApiConfig(XElement apiElement)
+        {
+            var config = new ApiConfig();
+
+            // Parse Url
+            var urlElement = apiElement.Element(nameof(ApiConfig.Url));
+            if (urlElement is not null && !string.IsNullOrWhiteSpace(urlElement.Value))
+            {
+                config.Url = urlElement.Value.Trim();
+            }
+
+            // Parse Proxy
+            var proxyElement = apiElement.Element(nameof(ApiConfig.Proxy));
+            if (proxyElement is not null && !string.IsNullOrWhiteSpace(proxyElement.Value))
+            {
+                if (bool.TryParse(proxyElement.Value.Trim(), out var proxy))
+                {
+                    config.Proxy = proxy;
+                }
+            }
+
+            // Parse OpenApi
+            var openApiElement = apiElement.Element(nameof(ApiConfig.OpenApi));
+            if (openApiElement is not null && !string.IsNullOrWhiteSpace(openApiElement.Value))
+            {
+                config.OpenApi = new ApiSpecConfig { Source = openApiElement.Value.Trim() };
+            }
+
+            // Parse AsyncApi
+            var asyncApiElement = apiElement.Element(nameof(ApiConfig.AsyncApi));
+            if (asyncApiElement is not null && !string.IsNullOrWhiteSpace(asyncApiElement.Value))
+            {
+                config.AsyncApi = new ApiSpecConfig { Source = asyncApiElement.Value.Trim() };
+            }
+
+            // Parse Playground
+            var playgroundElement = apiElement.Element(nameof(ApiConfig.Playground));
+            if (playgroundElement is not null)
+            {
+                config.Playground = new ApiPlaygroundConfig();
+
+                var displayElement = playgroundElement.Element(nameof(ApiPlaygroundConfig.Display));
+                if (displayElement is not null && !string.IsNullOrWhiteSpace(displayElement.Value))
+                {
+                    config.Playground.Display = displayElement.Value.Trim();
+                }
+
+                var playgroundProxyElement = playgroundElement.Element(nameof(ApiPlaygroundConfig.Proxy));
+                if (playgroundProxyElement is not null && !string.IsNullOrWhiteSpace(playgroundProxyElement.Value))
+                {
+                    if (bool.TryParse(playgroundProxyElement.Value.Trim(), out var playgroundProxy))
+                    {
+                        config.Playground.Proxy = playgroundProxy;
+                    }
+                }
+            }
+
+            // Parse Params
+            var paramsElement = apiElement.Element(nameof(ApiConfig.Params));
+            if (paramsElement is not null)
+            {
+                config.Params = new ApiParamsConfig();
+
+                var expandedElement = paramsElement.Element(nameof(ApiParamsConfig.Expanded));
+                if (expandedElement is not null && !string.IsNullOrWhiteSpace(expandedElement.Value))
+                {
+                    if (bool.TryParse(expandedElement.Value.Trim(), out var expanded))
+                    {
+                        config.Params.Expanded = expanded;
+                    }
+                }
+            }
+
+            // Parse Examples
+            var examplesElement = apiElement.Element(nameof(ApiConfig.Examples));
+            if (examplesElement is not null)
+            {
+                config.Examples = new ApiExamplesConfig();
+
+                var defaultsElement = examplesElement.Element(nameof(ApiExamplesConfig.Defaults));
+                if (defaultsElement is not null && !string.IsNullOrWhiteSpace(defaultsElement.Value))
+                {
+                    config.Examples.Defaults = defaultsElement.Value.Trim();
+                }
+
+                var prefillElement = examplesElement.Element(nameof(ApiExamplesConfig.Prefill));
+                if (prefillElement is not null && !string.IsNullOrWhiteSpace(prefillElement.Value))
+                {
+                    if (bool.TryParse(prefillElement.Value.Trim(), out var prefill))
+                    {
+                        config.Examples.Prefill = prefill;
+                    }
+                }
+
+                var autogenerateElement = examplesElement.Element(nameof(ApiExamplesConfig.Autogenerate));
+                if (autogenerateElement is not null && !string.IsNullOrWhiteSpace(autogenerateElement.Value))
+                {
+                    if (bool.TryParse(autogenerateElement.Value.Trim(), out var autogenerate))
+                    {
+                        config.Examples.Autogenerate = autogenerate;
+                    }
+                }
+
+                var languagesElement = examplesElement.Element(nameof(ApiExamplesConfig.Languages));
+                if (languagesElement is not null && !string.IsNullOrWhiteSpace(languagesElement.Value))
+                {
+                    config.Examples.Languages = languagesElement.Value
+                        .Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries)
+                        .Select(l => l.Trim())
+                        .Where(l => !string.IsNullOrWhiteSpace(l))
+                        .ToList();
+                }
+            }
+
+            // Parse Mdx
+            var mdxElement = apiElement.Element(nameof(ApiConfig.Mdx));
+            if (mdxElement is not null)
+            {
+                config.Mdx = new MdxConfig();
+
+                var serverElement = mdxElement.Element(nameof(MdxConfig.Server));
+                if (serverElement is not null && !string.IsNullOrWhiteSpace(serverElement.Value))
+                {
+                    config.Mdx.Server = new ServerConfig { Url = serverElement.Value.Trim() };
+                }
+
+                var authElement = mdxElement.Element(nameof(MdxConfig.Auth));
+                if (authElement is not null)
+                {
+                    config.Mdx.Auth = new MdxAuthConfig();
+
+                    var methodElement = authElement.Element(nameof(MdxAuthConfig.Method));
+                    if (methodElement is not null && !string.IsNullOrWhiteSpace(methodElement.Value))
+                    {
+                        config.Mdx.Auth.Method = methodElement.Value.Trim();
+                    }
+
+                    var nameElement = authElement.Element(nameof(MdxAuthConfig.Name));
+                    if (nameElement is not null && !string.IsNullOrWhiteSpace(nameElement.Value))
+                    {
+                        config.Mdx.Auth.Name = nameElement.Value.Trim();
+                    }
+                }
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Contextual element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="contextualElement">The contextual XML element.</param>
+        /// <returns>A ContextualConfig instance.</returns>
+        internal ContextualConfig ParseContextualConfig(XElement contextualElement)
+        {
+            var config = new ContextualConfig();
+
+            // Parse Options
+            var optionsElement = contextualElement.Element(nameof(ContextualConfig.Options));
+            if (optionsElement is not null && !string.IsNullOrWhiteSpace(optionsElement.Value))
+            {
+                config.Options = optionsElement.Value
+                    .Split(new[] { ';', ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(o => o.Trim())
+                    .Where(o => !string.IsNullOrWhiteSpace(o))
+                    .ToList();
+            }
+
+            // Parse Display
+            var displayElement = contextualElement.Element(nameof(ContextualConfig.Display));
+            if (displayElement is not null && !string.IsNullOrWhiteSpace(displayElement.Value))
+            {
+                config.Display = displayElement.Value.Trim();
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Fonts element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="fontsElement">The fonts XML element.</param>
+        /// <returns>A FontsConfig instance.</returns>
+        internal FontsConfig ParseFontsConfig(XElement fontsElement)
+        {
+            var config = new FontsConfig();
+
+            // Parse top-level font properties
+            var familyElement = fontsElement.Element(nameof(FontsConfig.Family));
+            if (familyElement is not null && !string.IsNullOrWhiteSpace(familyElement.Value))
+            {
+                config.Family = familyElement.Value.Trim();
+            }
+
+            var formatElement = fontsElement.Element(nameof(FontsConfig.Format));
+            if (formatElement is not null && !string.IsNullOrWhiteSpace(formatElement.Value))
+            {
+                config.Format = formatElement.Value.Trim();
+            }
+
+            var sourceElement = fontsElement.Element(nameof(FontsConfig.Source));
+            if (sourceElement is not null && !string.IsNullOrWhiteSpace(sourceElement.Value))
+            {
+                config.Source = sourceElement.Value.Trim();
+            }
+
+            var weightElement = fontsElement.Element(nameof(FontsConfig.Weight));
+            if (weightElement is not null && !string.IsNullOrWhiteSpace(weightElement.Value))
+            {
+                if (int.TryParse(weightElement.Value.Trim(), out var weight))
+                {
+                    config.Weight = weight;
+                }
+            }
+
+            // Parse Heading
+            var headingElement = fontsElement.Element(nameof(FontsConfig.Heading));
+            if (headingElement is not null)
+            {
+                config.Heading = ParseFontConfig(headingElement);
+            }
+
+            // Parse Body
+            var bodyElement = fontsElement.Element(nameof(FontsConfig.Body));
+            if (bodyElement is not null)
+            {
+                config.Body = ParseFontConfig(bodyElement);
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses a FontConfig element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="fontElement">The font XML element.</param>
+        /// <returns>A FontConfig instance.</returns>
+        internal FontConfig ParseFontConfig(XElement fontElement)
+        {
+            var config = new FontConfig();
+
+            var familyElement = fontElement.Element(nameof(FontConfig.Family));
+            if (familyElement is not null && !string.IsNullOrWhiteSpace(familyElement.Value))
+            {
+                config.Family = familyElement.Value.Trim();
+            }
+
+            var weightElement = fontElement.Element(nameof(FontConfig.Weight));
+            if (weightElement is not null && !string.IsNullOrWhiteSpace(weightElement.Value))
+            {
+                if (int.TryParse(weightElement.Value.Trim(), out var weight))
+                {
+                    config.Weight = weight;
+                }
+            }
+
+            var sourceElement = fontElement.Element(nameof(FontConfig.Source));
+            if (sourceElement is not null && !string.IsNullOrWhiteSpace(sourceElement.Value))
+            {
+                config.Source = sourceElement.Value.Trim();
+            }
+
+            var formatElement = fontElement.Element(nameof(FontConfig.Format));
+            if (formatElement is not null && !string.IsNullOrWhiteSpace(formatElement.Value))
+            {
+                config.Format = formatElement.Value.Trim();
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Thumbnails element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="thumbnailsElement">The thumbnails XML element.</param>
+        /// <returns>A ThumbnailsConfig instance.</returns>
+        internal ThumbnailsConfig ParseThumbnailsConfig(XElement thumbnailsElement)
+        {
+            var config = new ThumbnailsConfig();
+
+            var appearanceElement = thumbnailsElement.Element(nameof(ThumbnailsConfig.Appearance));
+            if (appearanceElement is not null && !string.IsNullOrWhiteSpace(appearanceElement.Value))
+            {
+                config.Appearance = appearanceElement.Value.Trim();
+            }
+
+            var backgroundElement = thumbnailsElement.Element(nameof(ThumbnailsConfig.Background));
+            if (backgroundElement is not null && !string.IsNullOrWhiteSpace(backgroundElement.Value))
+            {
+                config.Background = backgroundElement.Value.Trim();
+            }
+
+            var fontsElement = thumbnailsElement.Element(nameof(ThumbnailsConfig.Fonts));
+            if (fontsElement is not null)
+            {
+                config.Fonts = new ThumbnailFontsConfig();
+
+                var familyElement = fontsElement.Element(nameof(ThumbnailFontsConfig.Family));
+                if (familyElement is not null && !string.IsNullOrWhiteSpace(familyElement.Value))
+                {
+                    config.Fonts.Family = familyElement.Value.Trim();
+                }
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Metadata element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="metadataElement">The metadata XML element.</param>
+        /// <returns>A MetadataConfig instance.</returns>
+        internal MetadataConfig ParseMetadataConfig(XElement metadataElement)
+        {
+            var config = new MetadataConfig();
+
+            var timestampElement = metadataElement.Element(nameof(MetadataConfig.Timestamp));
+            if (timestampElement is not null && !string.IsNullOrWhiteSpace(timestampElement.Value))
+            {
+                if (bool.TryParse(timestampElement.Value.Trim(), out var timestamp))
+                {
+                    config.Timestamp = timestamp;
+                }
+            }
+
+            return config;
+        }
+
+        /// <summary>
+        /// Parses the Errors element from the MintlifyTemplate XML.
+        /// </summary>
+        /// <param name="errorsElement">The errors XML element.</param>
+        /// <returns>An ErrorsConfig instance.</returns>
+        internal ErrorsConfig ParseErrorsConfig(XElement errorsElement)
+        {
+            var config = new ErrorsConfig();
+
+            // The XML element name is "NotFound" but serializes as "404"
+            var notFoundElement = errorsElement.Element(nameof(ErrorsConfig.NotFound));
+            if (notFoundElement is not null)
+            {
+                config.NotFound = new Error404Config();
+
+                var redirectElement = notFoundElement.Element(nameof(Error404Config.Redirect));
+                if (redirectElement is not null && !string.IsNullOrWhiteSpace(redirectElement.Value))
+                {
+                    if (bool.TryParse(redirectElement.Value.Trim(), out var redirect))
+                    {
+                        config.NotFound.Redirect = redirect;
+                    }
+                }
+
+                var titleElement = notFoundElement.Element(nameof(Error404Config.Title));
+                if (titleElement is not null && !string.IsNullOrWhiteSpace(titleElement.Value))
+                {
+                    config.NotFound.Title = titleElement.Value.Trim();
+                }
+
+                var descriptionElement = notFoundElement.Element(nameof(Error404Config.Description));
+                if (descriptionElement is not null && !string.IsNullOrWhiteSpace(descriptionElement.Value))
+                {
+                    config.NotFound.Description = descriptionElement.Value.Trim();
                 }
             }
 

--- a/src/CloudNimble.DotNetDocs.Tests.Sdk.Tasks/GenerateDocumentationTaskTests.cs
+++ b/src/CloudNimble.DotNetDocs.Tests.Sdk.Tasks/GenerateDocumentationTaskTests.cs
@@ -556,6 +556,7 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
                 <Styling>
                     <Codeblocks>dark</Codeblocks>
                     <Eyebrows>subtle</Eyebrows>
+                    <Latex>true</Latex>
                 </Styling>
                 """;
             var stylingElement = XElement.Parse(xml);
@@ -567,6 +568,29 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
             result.Should().NotBeNull();
             result.Codeblocks.Should().Be("dark");
             result.Eyebrows.Should().Be("subtle");
+            result.Latex.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Tests that ParseStylingConfig correctly parses Latex property.
+        /// </summary>
+        [TestMethod]
+        public void ParseStylingConfig_WithLatex_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Styling>
+                    <Latex>false</Latex>
+                </Styling>
+                """;
+            var stylingElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseStylingConfig(stylingElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Latex.Should().BeFalse();
         }
 
         /// <summary>
@@ -586,6 +610,7 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
             result.Should().NotBeNull();
             result.Codeblocks.Should().BeNull();
             result.Eyebrows.Should().BeNull();
+            result.Latex.Should().BeNull();
         }
 
         #endregion
@@ -831,6 +856,656 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
             // Assert
             result.Should().NotBeNull();
             result.Drilldown.Should().BeTrue();
+        }
+
+        #endregion
+
+        #region Integrations Configuration Tests - New Integrations
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses PostHog SessionRecording.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithPostHogSessionRecording_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <PostHog ApiKey="phc_123" ApiHost="https://app.posthog.com" SessionRecording="true" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.PostHog.Should().NotBeNull();
+            result.PostHog!.ApiKey.Should().Be("phc_123");
+            result.PostHog.ApiHost.Should().Be("https://app.posthog.com");
+            result.PostHog.SessionRecording.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Adobe integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithAdobe_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Adobe LaunchUrl="https://assets.adobedtm.com/launch-abc123.min.js" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Adobe.Should().NotBeNull();
+            result.Adobe!.LaunchUrl.Should().Be("https://assets.adobedtm.com/launch-abc123.min.js");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Clarity integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithClarity_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Clarity ProjectId="abc123" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Clarity.Should().NotBeNull();
+            result.Clarity!.ProjectId.Should().Be("abc123");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Cookies integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithCookies_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Cookies Key="consent" Value="accepted" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Cookies.Should().NotBeNull();
+            result.Cookies!.Key.Should().Be("consent");
+            result.Cookies!.Value.Should().Be("accepted");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses FrontChat integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithFrontChat_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <FrontChat SnippetId="snippet_abc123" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.FrontChat.Should().NotBeNull();
+            result.FrontChat!.SnippetId.Should().Be("snippet_abc123");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Intercom integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithIntercom_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Intercom AppId="app_abc123" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Intercom.Should().NotBeNull();
+            result.Intercom!.AppId.Should().Be("app_abc123");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Koala integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithKoala_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Koala PublicApiKey="pk_abc123" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Koala.Should().NotBeNull();
+            result.Koala!.PublicApiKey.Should().Be("pk_abc123");
+        }
+
+        /// <summary>
+        /// Tests that ParseIntegrationsConfig correctly parses Telemetry integration.
+        /// </summary>
+        [TestMethod]
+        public void ParseIntegrationsConfig_WithTelemetry_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Integrations>
+                    <Telemetry Enabled="false" />
+                </Integrations>
+                """;
+            var integrationsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseIntegrationsConfig(integrationsElement);
+
+            // Assert
+            result.Telemetry.Should().NotBeNull();
+            result.Telemetry!.Enabled.Should().BeFalse();
+        }
+
+        #endregion
+
+        #region Api Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses Url property.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithUrl_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <Url>https://api.example.com</Url>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Url.Should().Be("https://api.example.com");
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses Proxy property.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithProxy_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <Proxy>false</Proxy>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Proxy.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses OpenApi spec.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithOpenApi_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <OpenApi>https://api.example.com/openapi.json</OpenApi>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.OpenApi.Should().NotBeNull();
+            result.OpenApi!.Source.Should().Be("https://api.example.com/openapi.json");
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses Examples with Autogenerate.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithExamplesAutogenerate_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <Examples>
+                        <Autogenerate>false</Autogenerate>
+                        <Defaults>required</Defaults>
+                        <Prefill>true</Prefill>
+                        <Languages>javascript;python;curl</Languages>
+                    </Examples>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Examples.Should().NotBeNull();
+            result.Examples!.Autogenerate.Should().BeFalse();
+            result.Examples.Defaults.Should().Be("required");
+            result.Examples.Prefill.Should().BeTrue();
+            result.Examples.Languages.Should().ContainInOrder("javascript", "python", "curl");
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses Playground config.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithPlayground_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <Playground>
+                        <Display>simple</Display>
+                        <Proxy>false</Proxy>
+                    </Playground>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Playground.Should().NotBeNull();
+            result.Playground!.Display.Should().Be("simple");
+            result.Playground.Proxy.Should().BeFalse();
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig correctly parses Params config.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithParams_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Api>
+                    <Params>
+                        <Expanded>true</Expanded>
+                    </Params>
+                </Api>
+                """;
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Params.Should().NotBeNull();
+            result.Params!.Expanded.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Tests that ParseApiConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseApiConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Api></Api>";
+            var apiElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseApiConfig(apiElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Url.Should().BeNull();
+            result.Proxy.Should().BeNull();
+            result.OpenApi.Should().BeNull();
+            result.AsyncApi.Should().BeNull();
+            result.Playground.Should().BeNull();
+            result.Params.Should().BeNull();
+            result.Examples.Should().BeNull();
+            result.Mdx.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Contextual Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseContextualConfig correctly parses Options and Display.
+        /// </summary>
+        [TestMethod]
+        public void ParseContextualConfig_WithAllProperties_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Contextual>
+                    <Options>copy;chatgpt;claude</Options>
+                    <Display>toc</Display>
+                </Contextual>
+                """;
+            var contextualElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseContextualConfig(contextualElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Options.Should().ContainInOrder("copy", "chatgpt", "claude");
+            result.Display.Should().Be("toc");
+        }
+
+        /// <summary>
+        /// Tests that ParseContextualConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseContextualConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Contextual></Contextual>";
+            var contextualElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseContextualConfig(contextualElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Options.Should().BeNull();
+            result.Display.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Fonts Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseFontsConfig correctly parses all top-level properties.
+        /// </summary>
+        [TestMethod]
+        public void ParseFontsConfig_WithTopLevelProperties_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Fonts>
+                    <Family>Open Sans</Family>
+                    <Format>woff2</Format>
+                    <Source>https://example.com/font.woff2</Source>
+                    <Weight>400</Weight>
+                </Fonts>
+                """;
+            var fontsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseFontsConfig(fontsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Family.Should().Be("Open Sans");
+            result.Format.Should().Be("woff2");
+            result.Source.Should().Be("https://example.com/font.woff2");
+            result.Weight.Should().Be(400);
+        }
+
+        /// <summary>
+        /// Tests that ParseFontsConfig correctly parses Heading and Body sub-configs.
+        /// </summary>
+        [TestMethod]
+        public void ParseFontsConfig_WithHeadingAndBody_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Fonts>
+                    <Heading>
+                        <Family>Playfair Display</Family>
+                        <Weight>700</Weight>
+                        <Source>https://example.com/heading.woff2</Source>
+                        <Format>woff2</Format>
+                    </Heading>
+                    <Body>
+                        <Family>Inter</Family>
+                        <Weight>400</Weight>
+                    </Body>
+                </Fonts>
+                """;
+            var fontsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseFontsConfig(fontsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Heading.Should().NotBeNull();
+            result.Heading!.Family.Should().Be("Playfair Display");
+            result.Heading.Weight.Should().Be(700);
+            result.Heading.Source.Should().Be("https://example.com/heading.woff2");
+            result.Heading.Format.Should().Be("woff2");
+            result.Body.Should().NotBeNull();
+            result.Body!.Family.Should().Be("Inter");
+            result.Body.Weight.Should().Be(400);
+        }
+
+        /// <summary>
+        /// Tests that ParseFontsConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseFontsConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Fonts></Fonts>";
+            var fontsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseFontsConfig(fontsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Family.Should().BeNull();
+            result.Format.Should().BeNull();
+            result.Source.Should().BeNull();
+            result.Weight.Should().BeNull();
+            result.Heading.Should().BeNull();
+            result.Body.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Thumbnails Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseThumbnailsConfig correctly parses all properties.
+        /// </summary>
+        [TestMethod]
+        public void ParseThumbnailsConfig_WithAllProperties_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Thumbnails>
+                    <Appearance>dark</Appearance>
+                    <Background>/images/bg.png</Background>
+                    <Fonts>
+                        <Family>Roboto</Family>
+                    </Fonts>
+                </Thumbnails>
+                """;
+            var thumbnailsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseThumbnailsConfig(thumbnailsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Appearance.Should().Be("dark");
+            result.Background.Should().Be("/images/bg.png");
+            result.Fonts.Should().NotBeNull();
+            result.Fonts!.Family.Should().Be("Roboto");
+        }
+
+        /// <summary>
+        /// Tests that ParseThumbnailsConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseThumbnailsConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Thumbnails></Thumbnails>";
+            var thumbnailsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseThumbnailsConfig(thumbnailsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Appearance.Should().BeNull();
+            result.Background.Should().BeNull();
+            result.Fonts.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Metadata Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseMetadataConfig correctly parses Timestamp property.
+        /// </summary>
+        [TestMethod]
+        public void ParseMetadataConfig_WithTimestamp_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Metadata>
+                    <Timestamp>true</Timestamp>
+                </Metadata>
+                """;
+            var metadataElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseMetadataConfig(metadataElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Timestamp.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// Tests that ParseMetadataConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseMetadataConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Metadata></Metadata>";
+            var metadataElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseMetadataConfig(metadataElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.Timestamp.Should().BeNull();
+        }
+
+        #endregion
+
+        #region Errors Configuration Tests
+
+        /// <summary>
+        /// Tests that ParseErrorsConfig correctly parses NotFound with all properties.
+        /// </summary>
+        [TestMethod]
+        public void ParseErrorsConfig_WithAllProperties_ParsesCorrectly()
+        {
+            // Arrange
+            var xml = """
+                <Errors>
+                    <NotFound>
+                        <Redirect>false</Redirect>
+                        <Title>Oops!</Title>
+                        <Description>The page you were looking for doesn't exist.</Description>
+                    </NotFound>
+                </Errors>
+                """;
+            var errorsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseErrorsConfig(errorsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.NotFound.Should().NotBeNull();
+            result.NotFound!.Redirect.Should().BeFalse();
+            result.NotFound.Title.Should().Be("Oops!");
+            result.NotFound.Description.Should().Be("The page you were looking for doesn't exist.");
+        }
+
+        /// <summary>
+        /// Tests that ParseErrorsConfig handles empty element.
+        /// </summary>
+        [TestMethod]
+        public void ParseErrorsConfig_WithEmptyElement_ReturnsEmptyConfig()
+        {
+            // Arrange
+            var xml = "<Errors></Errors>";
+            var errorsElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseErrorsConfig(errorsElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result.NotFound.Should().BeNull();
         }
 
         #endregion


### PR DESCRIPTION
## Summary
- Adds XML parsing for 7 new integration configs (Adobe, Clarity, Cookies, FrontChat, Intercom, Koala, Telemetry) and PostHog.SessionRecording to `ParseIntegrationsConfig`
- Adds 6 new Parse methods and wires them into `ParseMintlifyTemplate` for: Api, Contextual, Fonts, Thumbnails, Metadata, Errors
- Adds 28 new unit tests covering all new parsing logic
- All 399 tests pass across net8.0, net9.0, and net10.0

## Context
PR #52 added many new model properties but `GenerateDocumentationTask` was not updated to parse them from the `.docsproj` XML, so they were never populated in the output `docs.json`.

## Test plan
- [x] All 399 existing + new tests pass on all 3 target frameworks
- [ ] Verify end-to-end with a `.docsproj` using new config sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)