### PR TITLE
Parse Root and Expanded attributes on navigation <Group> elements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,8 @@
       "WebFetch(domain:www.nuget.org)",
       "WebFetch(domain:www.anthropic.com)",
       "Bash(gh run:*)",
-      "Bash(gh workflow:*)"
+      "Bash(gh workflow:*)",
+      "Bash(git rev-list *)"
     ],
     "deny": [],
     "ask": [],

--- a/src/CloudNimble.DotNetDocs.Sdk.Tasks/CloudNimble.DotNetDocs.Sdk.Tasks.csproj
+++ b/src/CloudNimble.DotNetDocs.Sdk.Tasks/CloudNimble.DotNetDocs.Sdk.Tasks.csproj
@@ -21,7 +21,6 @@
     <ItemGroup>
         <!-- MSBuild task dependencies -->
         <PackageReference Include="EasyAF.MSBuild" Version="4.*" />
-        <PackageReference Include="System.Collections.Immutable" Version="9.*" PrivateAssets="all" />
 
         <!-- Microsoft.CodeAnalysis.CSharp.Workspaces needs to be available for the task -->
         <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.*" />
@@ -30,14 +29,26 @@
     <!-- Framework-specific dependencies -->
     <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.*" />
+        <PackageReference Include="System.Collections.Immutable" Version="10.*" PrivateAssets="all" />
+
+        <!-- Vulnerability fix -->
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.*" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.*" PrivateAssets="all" />
+
+        <!-- Vulnerability fix -->
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.*" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
         <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
+        <PackageReference Include="System.Collections.Immutable" Version="9.*" PrivateAssets="all" />
+
+        <!-- Vulnerability fix -->
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="9.*" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">

--- a/src/CloudNimble.DotNetDocs.Sdk.Tasks/GenerateDocumentationTask.cs
+++ b/src/CloudNimble.DotNetDocs.Sdk.Tasks/GenerateDocumentationTask.cs
@@ -779,6 +779,20 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
         /// </summary>
         /// <param name="groupElement">The group XML element.</param>
         /// <returns>A GroupConfig instance, or null if parsing fails.</returns>
+        /// <remarks>
+        /// Requires a <c>Name</c> attribute. Optional attributes include <c>Icon</c>, <c>Tag</c>,
+        /// <c>Root</c> (the default page shown when the group is selected), and <c>Expanded</c>
+        /// (<c>true</c>/<c>false</c>, controlling the group's default expand/collapse state).
+        /// Child <c>&lt;Pages&gt;</c> and nested <c>&lt;Group&gt;</c> elements (optionally wrapped in
+        /// <c>&lt;Groups&gt;</c>) are also parsed.
+        /// </remarks>
+        /// <example>
+        /// <code>
+        /// &lt;Group Name="Episodes" Icon="microphone" Root="Brands/WhatsYourStory/Episodes/index" Expanded="false"&gt;
+        ///     &lt;Pages&gt;Brands/WhatsYourStory/Episodes/index;Brands/WhatsYourStory/Episodes/analysis&lt;/Pages&gt;
+        /// &lt;/Group&gt;
+        /// </code>
+        /// </example>
         internal GroupConfig? ParseGroupConfig(XElement groupElement)
         {
             var groupName = groupElement.Attribute("Name")?.Value;
@@ -793,8 +807,16 @@ namespace CloudNimble.DotNetDocs.Sdk.Tasks
                 Group = groupName,
                 Icon = groupElement.Attribute("Icon")?.Value,
                 Tag = groupElement.Attribute("Tag")?.Value,
+                Root = groupElement.Attribute("Root")?.Value,
                 Pages = []
             };
+
+            // Parse the optional Expanded attribute, which controls the group's default expand/collapse state.
+            var expandedAttr = groupElement.Attribute("Expanded")?.Value;
+            if (!string.IsNullOrWhiteSpace(expandedAttr) && bool.TryParse(expandedAttr, out var expanded))
+            {
+                group.Expanded = expanded;
+            }
 
             // Parse direct pages (semicolon-separated list)
             var pagesElement = groupElement.Element(nameof(GroupConfig.Pages));

--- a/src/CloudNimble.DotNetDocs.Tests.Sdk.Tasks/GenerateDocumentationTaskTests.cs
+++ b/src/CloudNimble.DotNetDocs.Tests.Sdk.Tasks/GenerateDocumentationTaskTests.cs
@@ -48,14 +48,14 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
         #region MintlifyTemplate XML Parsing Tests
 
         /// <summary>
-        /// Tests that ParseGroupConfig correctly extracts group name, icon, and tag from XML.
+        /// Tests that ParseGroupConfig correctly extracts group name, icon, tag, root, and expanded from XML.
         /// </summary>
         [TestMethod]
         public void ParseGroupConfig_WithCompleteAttributes_ParsesAllProperties()
         {
             // Arrange
             var xml = """
-                <Group Name="Getting Started" Icon="stars" Tag="CORE">
+                <Group Name="Getting Started" Icon="stars" Tag="CORE" Root="getting-started/index" Expanded="false">
                     <Pages>index;quickstart</Pages>
                 </Group>
                 """;
@@ -69,9 +69,107 @@ namespace CloudNimble.DotNetDocs.Tests.Sdk.Tasks
             result!.Group.Should().Be("Getting Started");
             result.Icon!.Name.Should().Be("stars");
             result.Tag.Should().Be("CORE");
+            result.Root.Should().Be("getting-started/index");
+            result.Expanded.Should().BeFalse();
             result.Pages.Should().HaveCount(2);
             result.Pages![0].Should().Be("index");
             result.Pages![1].Should().Be("quickstart");
+        }
+
+        /// <summary>
+        /// Tests that ParseGroupConfig parses the Root attribute, used to disambiguate identically-named
+        /// groups across sections and to provide a landing page when the group is selected.
+        /// </summary>
+        [TestMethod]
+        public void ParseGroupConfig_WithRootAttribute_ParsesRoot()
+        {
+            // Arrange
+            var xml = """
+                <Group Name="Episodes" Icon="microphone" Root="Brands/WhatsYourStory/Episodes/index">
+                    <Pages>Brands/WhatsYourStory/Episodes/index</Pages>
+                </Group>
+                """;
+            var groupElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseGroupConfig(groupElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Root.Should().Be("Brands/WhatsYourStory/Episodes/index");
+        }
+
+        /// <summary>
+        /// Tests that ParseGroupConfig leaves Root null when the attribute is absent.
+        /// </summary>
+        [TestMethod]
+        public void ParseGroupConfig_WithoutRoot_HasNullRoot()
+        {
+            // Arrange
+            var xml = """
+                <Group Name="Episodes" Icon="microphone">
+                    <Pages>index</Pages>
+                </Group>
+                """;
+            var groupElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseGroupConfig(groupElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Root.Should().BeNull();
+        }
+
+        /// <summary>
+        /// Tests that ParseGroupConfig parses the Expanded attribute for both true and false values.
+        /// </summary>
+        [TestMethod]
+        [DataRow("true", true)]
+        [DataRow("false", false)]
+        [DataRow("True", true)]
+        public void ParseGroupConfig_WithExpandedAttribute_ParsesExpanded(string value, bool expected)
+        {
+            // Arrange
+            var xml = $"""
+                <Group Name="Episodes" Icon="microphone" Expanded="{value}">
+                    <Pages>index</Pages>
+                </Group>
+                """;
+            var groupElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseGroupConfig(groupElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Expanded.Should().Be(expected);
+        }
+
+        /// <summary>
+        /// Tests that ParseGroupConfig leaves Expanded null when the attribute is absent or not a valid boolean.
+        /// </summary>
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow("yes")]
+        public void ParseGroupConfig_WithMissingOrInvalidExpanded_LeavesExpandedNull(string? value)
+        {
+            // Arrange
+            var attr = value is null ? "" : $@" Expanded=""{value}""";
+            var xml = $"""
+                <Group Name="Episodes" Icon="microphone"{attr}>
+                    <Pages>index</Pages>
+                </Group>
+                """;
+            var groupElement = XElement.Parse(xml);
+
+            // Act
+            var result = _task.ParseGroupConfig(groupElement);
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.Expanded.Should().BeNull();
         }
 
         /// <summary>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.100",
+    "version": "10.0.300",
     "rollForward": "latestPatch"
   },
   "test": {


### PR DESCRIPTION
## Summary

`ParseGroupConfig` only read `Name`, `Icon`, and `Tag`, so a template `<Group>` could not set `GroupConfig.Root` or `GroupConfig.Expanded` — even though both exist on the model and serialize to `docs.json`. That made it impossible to give identically-named groups a distinct **root** page.

This matters for sidebars that repeat group names across sibling sections (e.g. a "Brands" tab where each brand has its own `Episodes`, `Planning`, `Competitive Analysis`, … groups). Mintlify keys a group's sidebar expand/collapse state off its identity; without a unique `root`, the same-named groups expand/collapse together. Setting `Root` per group decouples them (and gives each a landing page).

## Changes

- **`ParseGroupConfig`** now reads the optional `Root` (string) and `Expanded` (bool) attributes.
  - `Root` → `GroupConfig.Root`, optional (null when omitted — no required check).
  - `Expanded` → `GroupConfig.Expanded`, parsed with the existing `!IsNullOrWhiteSpace && bool.TryParse` convention; left null when absent or non-boolean.
  - Added `<remarks>` + `<example>` documenting all supported `<Group>` attributes.
- **Tests** (`GenerateDocumentationTaskTests`): `Root` present/absent, `Expanded` true/false/`True`, and missing/invalid `Expanded` → null; extended the complete-attributes test.
- **Build/security:** pinned `System.Security.Cryptography.Xml` above the transitive `9.0.0` (high-severity advisories `GHSA-37gx-xxp4-5rgx`, `GHSA-w3x6-4m5h-cxqf`), per TFM (net10 → `10.*`, net9/8 → `9.*`), so restore passes with NuGet audit enabled.

## Verification

- `ParseGroupConfig` test suite: **22 passed, 0 failed** (net10, MSTest/MTP runner).
- Restore succeeds with the NuGet audit **enabled** (NU1903 resolved).

## Notes

Both new attributes are fully optional and backward-compatible — existing templates are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)